### PR TITLE
Check if worlds are loaded

### DIFF
--- a/src/cosmicpe/blockdata/world/BlockDataWorldListener.php
+++ b/src/cosmicpe/blockdata/world/BlockDataWorldListener.php
@@ -50,7 +50,7 @@ final class BlockDataWorldListener implements Listener{
 	 */
 	public function onWorldSave(WorldSaveEvent $event) : void{
 		$world = $event->getWorld();
-		if($world->getAutoSave()){
+		if($world->getAutoSave() && $this->manager->isLoaded($world)){
 			$this->manager->save($world);
 		}
 	}
@@ -78,6 +78,9 @@ final class BlockDataWorldListener implements Listener{
 	 */
 	public function onChunkUnload(ChunkUnloadEvent $event) : void{
 		$chunk = $event->getChunk();
-		$this->manager->get($event->getWorld())->unloadChunk($chunk->getX(), $chunk->getZ());
+		$world = $event->getWorld();
+		if($this->manager->isLoaded($world)){
+			$this->manager->get($world)->unloadChunk($chunk->getX(), $chunk->getZ());
+		}
 	}
 }

--- a/src/cosmicpe/blockdata/world/BlockDataWorldManager.php
+++ b/src/cosmicpe/blockdata/world/BlockDataWorldManager.php
@@ -32,6 +32,10 @@ final class BlockDataWorldManager{
 		$this->plugin = $plugin;
 	}
 
+	public function isLoaded(World $world) : bool{
+		return isset($this->worlds[$world->getId()]);
+	}
+
 	public function load(World $world) : void{
 		$this->worlds[$world->getId()] = new BlockDataWorld($this->plugin, $world);
 	}


### PR DESCRIPTION
Apparently, PocketMine saves the world and unloads chunks after calling WorldUnloadEvent, causing BlockData to throw an error since it unloads the world from cache on WorldUnloadEvent.

This pull request solves that issue (#4)  by simply adding an isLoaded check.

(i also apparently made the commit message wrong, it's meant to be check if worlds* are loaded, lol)