### PR TITLE
Remove deprecated LevelDB::close()

### DIFF
--- a/src/cosmicpe/blockdata/world/BlockDataWorld.php
+++ b/src/cosmicpe/blockdata/world/BlockDataWorld.php
@@ -78,6 +78,6 @@ final class BlockDataWorld{
 			World::getXZ($hash, $chunkX, $chunkZ);
 			$this->unloadChunk($chunkX, $chunkZ, $save);
 		}
-		$this->database->close();
+		unset($this->database);
 	}
 }


### PR DESCRIPTION
Since https://github.com/pmmp/php-build-scripts/commit/c64baa0f1cef695df7ed564e82e02f0399c0ba14, LevelDB::close() is deprecated in pmmp php bins. This PR removes that and replaces it with `unset()`, referencing https://github.com/reeze/php-leveldb/commit/f1ca2809d84fd6db606267e1a1009566e026590a. (though I'm not sure if that's really needed)