### PR TITLE
Fix: setting null causing a db read

### DIFF
--- a/src/cosmicpe/blockdata/world/BlockDataChunk.php
+++ b/src/cosmicpe/blockdata/world/BlockDataChunk.php
@@ -12,6 +12,7 @@ use pocketmine\nbt\BaseNbtSerializer;
 use pocketmine\nbt\BigEndianNbtSerializer;
 use pocketmine\nbt\TreeRoot;
 use pocketmine\world\World;
+use function array_key_exists;
 
 final class BlockDataChunk{
 
@@ -33,7 +34,7 @@ final class BlockDataChunk{
 	}
 
 	public function getBlockDataAt(int $x, int $y, int $z) : ?BlockData{
-		if(!isset($this->block_cache[$hash = World::blockHash($x, $y, $z)])){
+		if(!array_key_exists($hash = World::blockHash($x, $y, $z), $this->block_cache)){
 			$buffer = $this->database->get("b" . $hash);
 			if($buffer !== false){
 				$this->block_cache[$hash] = BlockDataFactory::nbtDeserialize($this->serializer->read($buffer)->mustGetCompoundTag());


### PR DESCRIPTION
While setting null does update the cache, since `isset` returns false on null, BlockData goes back to the database and reads the old value. This PR replaces it with `array_key_exists` and solves the problem.